### PR TITLE
Fix UUID library and failing tests

### DIFF
--- a/association_test.go
+++ b/association_test.go
@@ -1,17 +1,18 @@
 package gopenid
 
 import (
-	"code.google.com/p/go-uuid/uuid"
 	"crypto/hmac"
 	"crypto/rand"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAssociation(t *testing.T) {
-	handle := uuid.New()
+	handle := uuid.New().String()
 	secret := make([]byte, DefaultAssoc.GetSecretSize())
 	_, err := io.ReadFull(rand.Reader, secret)
 	if !assert.Nil(t, err) {

--- a/association_test.go
+++ b/association_test.go
@@ -44,7 +44,7 @@ func TestAssociation(t *testing.T) {
 	if assert.Nil(t, err) {
 		signed, ok := msg.GetArg(NewMessageKey(NsOpenID20, "signed"))
 		if assert.True(t, ok) {
-			assert.Equal(t, signed, "mode,ns")
+			assert.Equal(t, signed.String(), "mode,ns")
 
 			sig, ok := msg.GetArg(NewMessageKey(NsOpenID20, "sig"))
 			if assert.True(t, ok) {

--- a/message_test.go
+++ b/message_test.go
@@ -3,10 +3,11 @@ package gopenid
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/url"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type messageFromQueryCase struct {
@@ -160,7 +161,7 @@ func TestMessage(t *testing.T) {
 	assert.Equal(t, msg.GetOpenIDNamespace(), NsOpenID20)
 
 	if nsuri, ok := msg.GetNamespaceURI("example"); assert.True(t, ok) {
-		assert.Equal(t, nsuri, "http://example.com/")
+		assert.Equal(t, nsuri.String(), "http://example.com/")
 	}
 
 	if nsalias, ok := msg.GetNamespaceAlias("http://example.com/"); assert.True(t, ok) {
@@ -168,16 +169,16 @@ func TestMessage(t *testing.T) {
 	}
 
 	if arg, ok := msg.GetArg(NewMessageKey(NsExt, "foo")); assert.True(t, ok) {
-		assert.Equal(t, arg, "bar")
+		assert.Equal(t, arg.String(), "bar")
 	}
 	if arg, ok := msg.GetArg(NewMessageKey(NsExt, "hoge")); assert.True(t, ok) {
-		assert.Equal(t, arg, "fuga")
+		assert.Equal(t, arg.String(), "fuga")
 	}
 	if arg, ok := msg.GetArg(NewMessageKey(NsOpenID20, "mode")); assert.True(t, ok) {
-		assert.Equal(t, arg, "checkid_immediate")
+		assert.Equal(t, arg.String(), "checkid_immediate")
 	}
 	if arg, ok := msg.GetArg(NewMessageKey(NsOpenID20, "return_to")); assert.True(t, ok) {
-		assert.Equal(t, arg, "http://www.example.com/")
+		assert.Equal(t, arg.String(), "http://www.example.com/")
 	}
 	_, ok := msg.GetArg(NewMessageKey(NsOpenID20, "notgiven"))
 	assert.False(t, ok)

--- a/provider/signer.go
+++ b/provider/signer.go
@@ -1,12 +1,13 @@
 package provider
 
 import (
-	"code.google.com/p/go-uuid/uuid"
 	"errors"
-	"github.com/GehirnInc/GOpenID"
 	"io"
 	"strings"
 	"time"
+
+	"github.com/GehirnInc/GOpenID"
+	"github.com/google/uuid"
 )
 
 var (
@@ -36,7 +37,7 @@ func NewSigner(store gopenid.Store, lifetime time.Duration, secretGenerator io.R
 }
 
 func (s *Signer) createAssociation(assocType gopenid.AssocType, isStateless bool) (assoc *gopenid.Association, err error) {
-	handle := uuid.New()
+	handle := uuid.New().String()
 	secret := make([]byte, assocType.GetSecretSize())
 	_, err = io.ReadFull(s.secretGenerator, secret)
 	if err != nil {


### PR DESCRIPTION
The UUID library used no longer exists, so this uses its replacement.

It also fixes some tests that were failing due to MessageValue vs. string type.